### PR TITLE
Add LSTM vs STC notebook

### DIFF
--- a/compare_boot_model.py
+++ b/compare_boot_model.py
@@ -1,0 +1,79 @@
+import csv
+from statistics import mean
+import random
+from math import sqrt
+
+
+def load_close_prices(path):
+    closes = []
+    with open(path, newline='') as csvfile:
+        reader = csv.DictReader(csvfile)
+        for row in reader:
+            closes.append(float(row['Close']))
+    return closes
+
+
+def create_dataset(closes):
+    X = closes[:-1]
+    y = closes[1:]
+    return X, y
+
+
+def linear_regression(X, y):
+    n = len(X)
+    mean_x = mean(X)
+    mean_y = mean(y)
+    var_x = sum((x - mean_x) ** 2 for x in X)
+    cov_xy = sum((x - mean_x) * (y_i - mean_y) for x, y_i in zip(X, y))
+    slope = cov_xy / var_x
+    intercept = mean_y - slope * mean_x
+    return intercept, slope
+
+
+def bootstrap_models(X, y, n_boot=10):
+    models = []
+    n = len(X)
+    for _ in range(n_boot):
+        indices = [random.randrange(n) for _ in range(n)]
+        Xb = [X[i] for i in indices]
+        yb = [y[i] for i in indices]
+        models.append(linear_regression(Xb, yb))
+    return models
+
+
+def predict_boot(models, x):
+    total = 0.0
+    for intercept, slope in models:
+        total += intercept + slope * x
+    return total / len(models)
+
+
+def train_test_split(X, y, test_ratio=0.2):
+    split_idx = int(len(X) * (1 - test_ratio))
+    return X[:split_idx], X[split_idx:], y[:split_idx], y[split_idx:]
+
+
+def mse(preds, actual):
+    return sum((p - a) ** 2 for p, a in zip(preds, actual)) / len(preds)
+
+
+if __name__ == '__main__':
+    path = 'MSFT_1986_2025-06-30.csv'
+    closes = load_close_prices(path)
+    X, y = create_dataset(closes)
+    X_train, X_test, y_train, y_test = train_test_split(X, y)
+
+    base_intercept, base_slope = linear_regression(X_train, y_train)
+    base_preds = [base_intercept + base_slope * x for x in X_test]
+    base_error = mse(base_preds, y_test)
+
+    boot_models = bootstrap_models(X_train, y_train, n_boot=30)
+    boot_preds = [predict_boot(boot_models, x) for x in X_test]
+    boot_error = mse(boot_preds, y_test)
+
+    print(f'Base Linear Regression MSE: {base_error:.6f}')
+    print(f'Bootstrap Ensemble MSE:   {boot_error:.6f}')
+    if boot_error < base_error:
+        print('Bootstrap ensemble performed better.')
+    else:
+        print('Base linear regression performed better.')

--- a/compare_lstm_stc.ipynb
+++ b/compare_lstm_stc.ipynb
@@ -1,0 +1,163 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# LSTM vs STC Comparison\n",
+    "\n",
+    "This notebook loads Microsoft stock data, trains an LSTM model to predict whether the next day's closing price will increase, and compares it with a simple Schaff Trend Cycle (STC) baseline."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "from sklearn.preprocessing import MinMaxScaler\n",
+    "from sklearn.metrics import accuracy_score\n",
+    "from tensorflow.keras.models import Sequential\n",
+    "from tensorflow.keras.layers import LSTM, Dense"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["## Load Data"]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.read_csv('MSFT_1986_2025-06-30.csv')\n",
+    "df['Date'] = pd.to_datetime(df['Date'])\n",
+    "df = df.sort_values('Date').reset_index(drop=True)\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["## Calculate STC"]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def schaff_trend_cycle(close, fast_period=23, slow_period=50, cycle_period=10):\n",
+    "    ema_fast = close.ewm(span=fast_period, adjust=False).mean()\n",
+    "    ema_slow = close.ewm(span=slow_period, adjust=False).mean()\n",
+    "    macd = ema_fast - ema_slow\n",
+    "    lowest_macd = macd.rolling(window=cycle_period).min()\n",
+    "    highest_macd = macd.rolling(window=cycle_period).max()\n",
+    "    stoch_macd = 100 * (macd - lowest_macd) / (highest_macd - lowest_macd)\n",
+    "    stoch_macd_smoothed1 = stoch_macd.ewm(span=3, adjust=False).mean()\n",
+    "    stoch_macd_smoothed2 = stoch_macd_smoothed1.ewm(span=3, adjust=False).mean()\n",
+    "    return stoch_macd_smoothed2\n",
+    "\n",
+    "df['STC'] = schaff_trend_cycle(df['Close'])\n",
+    "df = df.dropna().reset_index(drop=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["## Prepare Data for LSTM"]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df['Target'] = (df['Close'].shift(-1) > df['Close']).astype(int)\n",
+    "scaler = MinMaxScaler()\n",
+    "scaled_close = scaler.fit_transform(df[['Close']])\n",
+    "seq_len = 20\n",
+    "X, y = [], []\n",
+    "for i in range(len(scaled_close)-seq_len-1):\n",
+    "    X.append(scaled_close[i:i+seq_len])\n",
+    "    y.append(df['Target'].iloc[i+seq_len])\n",
+    "X, y = np.array(X), np.array(y)\n",
+    "split = int(0.8 * len(X))\n",
+    "X_train, X_test = X[:split], X[split:]\n",
+    "y_train, y_test = y[:split], y[split:]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["## Train LSTM"]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = Sequential([\n",
+    "    LSTM(50, input_shape=(X_train.shape[1], X_train.shape[2])),\n",
+    "    Dense(1, activation='sigmoid')\n",
+    "])\n",
+    "model.compile(optimizer='adam', loss='binary_crossentropy', metrics=['accuracy'])\n",
+    "model.fit(X_train, y_train, epochs=3, batch_size=32, verbose=0)\n",
+    "lstm_pred = (model.predict(X_test) > 0.5).astype(int).flatten()\n",
+    "lstm_acc = accuracy_score(y_test, lstm_pred)\n",
+    "print('LSTM accuracy:', lstm_acc)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["## STC Baseline"]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stc_signal = (df['STC'] > 50).astype(int)\n",
+    "stc_pred = stc_signal.shift(1).dropna().iloc[seq_len:]\n",
+    "stc_true = df['Target'].iloc[seq_len+1:]\n",
+    "stc_acc = accuracy_score(stc_true, stc_pred)\n",
+    "print('STC baseline accuracy:', stc_acc)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["## Comparison"]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('LSTM Accuracy:', lstm_acc)\n",
+    "print('STC Baseline Accuracy:', stc_acc)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Summary
- add a new notebook to compare an LSTM classifier with an STC-based baseline

## Testing
- `python3 compare_boot_model.py`


------
https://chatgpt.com/codex/tasks/task_e_6874b2064424832db713cdcbc8648973