### PR TITLE
Add CapsNet comparison notebook

### DIFF
--- a/capsnet_without_and_with_indicators.ipynb
+++ b/capsnet_without_and_with_indicators.ipynb
@@ -1,0 +1,276 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# CapsNet on Microsoft Stock\n",
+    "\n",
+    "This notebook trains a Capsule Network (CapsNet) on Microsoft stock price data.\n",
+    "First it uses only raw OHLCV features, then it adds two technical indicators\n",
+    "Schaff Trend Cycle (STC) and Chande Momentum Oscillator (CMO). The results\n",
+    "from both approaches are compared at the end."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "from sklearn.preprocessing import MinMaxScaler\n",
+    "from sklearn.metrics import accuracy_score, recall_score, f1_score\n",
+    "from tensorflow.keras import layers, models\n",
+    "import tensorflow as tf"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Helper functions\n",
+    "Capsule network layers and evaluation utilities."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def squash(vectors, axis=-1):\n",
+    "    s_squared_norm = tf.reduce_sum(tf.square(vectors), axis=axis, keepdims=True)\n",
+    "    scale = s_squared_norm / (1 + s_squared_norm) / tf.sqrt(s_squared_norm + 1e-7)\n",
+    "    return scale * vectors\n",
+    "\n",
+    "class CapsuleLayer(layers.Layer):\n",
+    "    def __init__(self, num_capsules, dim_capsule, routings=3, **kwargs):\n",
+    "        super().__init__(**kwargs)\n",
+    "        self.num_capsules = num_capsules\n",
+    "        self.dim_capsule = dim_capsule\n",
+    "        self.routings = routings\n",
+    "\n",
+    "    def build(self, input_shape):\n",
+    "        self.input_num_capsules = input_shape[1]\n",
+    "        self.input_dim_capsule = input_shape[2]\n",
+    "        self.W = self.add_weight(\n",
+    "            shape=[1, self.input_num_capsules, self.num_capsules,\n",
+    "                   self.input_dim_capsule, self.dim_capsule],\n",
+    "            initializer='glorot_uniform',\n",
+    "            trainable=True,\n",
+    "            name='W')\n",
+    "\n",
+    "    def call(self, inputs):\n",
+    "        batch_size = tf.shape(inputs)[0]\n",
+    "        inputs_expand = tf.expand_dims(tf.expand_dims(inputs, 2), 2)\n",
+    "        inputs_tiled = tf.tile(inputs_expand, [1, 1, self.num_capsules, 1, 1])\n",
+    "        W_tiled = tf.tile(self.W, [batch_size, 1, 1, 1, 1])\n",
+    "        u_hat = tf.matmul(inputs_tiled, W_tiled)\n",
+    "        u_hat = tf.squeeze(u_hat, [3])\n",
+    "        b = tf.zeros([batch_size, self.input_num_capsules, self.num_capsules, 1])\n",
+    "        for i in range(self.routings):\n",
+    "            c = tf.nn.softmax(b, axis=2)\n",
+    "            s = tf.reduce_sum(c * u_hat, axis=1, keepdims=True)\n",
+    "            v = squash(s)\n",
+    "            if i < self.routings - 1:\n",
+    "                b += tf.reduce_sum(u_hat * v, axis=-1, keepdims=True)\n",
+    "        return tf.squeeze(v, [1])\n",
+    "\n",
+    "class Length(layers.Layer):\n",
+    "    def call(self, inputs, **kwargs):\n",
+    "        return tf.sqrt(tf.reduce_sum(tf.square(inputs), axis=-1))\n",
+    "\n",
+    "def build_capsnet(input_shape, num_classes=2):\n",
+    "    inputs = layers.Input(shape=input_shape)\n",
+    "    x = layers.Conv1D(64, 5, padding='same', activation='relu')(inputs)\n",
+    "    x = layers.BatchNormalization()(x)\n",
+    "    x = layers.Conv1D(32, 5, strides=2, activation='relu')(x)\n",
+    "    x = layers.Reshape((-1, 8))(x)\n",
+    "    x = layers.Lambda(squash)(x)\n",
+    "    digitcaps = CapsuleLayer(num_capsules=num_classes, dim_capsule=8, routings=3)(x)\n",
+    "    out_caps = Length()(digitcaps)\n",
+    "    model = models.Model(inputs, out_caps)\n",
+    "    model.compile(optimizer='adam', loss='binary_crossentropy', metrics=['accuracy'])\n",
+    "    return model\n",
+    "\n",
+    "def evaluate(y_true, y_pred):\n",
+    "    return {\n",
+    "        'accuracy': accuracy_score(y_true, y_pred),\n",
+    "        'recall': recall_score(y_true, y_pred),\n",
+    "        'f1': f1_score(y_true, y_pred)\n",
+    "    }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Technical indicators\n",
+    "Functions to compute STC and CMO when needed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def schaff_trend_cycle(close, fast_period=23, slow_period=50, cycle_period=10):\n",
+    "    ema_fast = close.ewm(span=fast_period, adjust=False).mean()\n",
+    "    ema_slow = close.ewm(span=slow_period, adjust=False).mean()\n",
+    "    macd = ema_fast - ema_slow\n",
+    "    lowest_macd = macd.rolling(window=cycle_period).min()\n",
+    "    highest_macd = macd.rolling(window=cycle_period).max()\n",
+    "    stoch_macd = 100 * (macd - lowest_macd) / (highest_macd - lowest_macd)\n",
+    "    stoch_macd_smoothed1 = stoch_macd.ewm(span=3, adjust=False).mean()\n",
+    "    stoch_macd_smoothed2 = stoch_macd_smoothed1.ewm(span=3, adjust=False).mean()\n",
+    "    return stoch_macd_smoothed2\n",
+    "\n",
+    "def chande_momentum_oscillator(close, window=14):\n",
+    "    delta = close.diff()\n",
+    "    gains = delta.where(delta > 0, 0)\n",
+    "    losses = -delta.where(delta < 0, 0)\n",
+    "    sum_gains = gains.rolling(window=window).sum()\n",
+    "    sum_losses = losses.rolling(window=window).sum()\n",
+    "    cmo = 100 * (sum_gains - sum_losses) / (sum_gains + sum_losses)\n",
+    "    return cmo"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Data preparation\n",
+    "Create sequences of fixed length for model training." 
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def load_data(path, use_indicators=False):\n",
+    "    df = pd.read_csv(path)\n",
+    "    df['Date'] = pd.to_datetime(df['Date'])\n",
+    "    df = df.sort_values('Date').reset_index(drop=True)\n",
+    "    if use_indicators:\n",
+    "        df['STC'] = schaff_trend_cycle(df['Close'])\n",
+    "        df['CMO'] = chande_momentum_oscillator(df['Close'])\n",
+    "        features = ['Close','High','Low','Open','Volume','STC','CMO']\n",
+    "    else:\n",
+    "        features = ['Close','High','Low','Open','Volume']\n",
+    "    df['Target'] = (df['Close'].shift(-1) > df['Close']).astype(int)\n",
+    "    df = df.dropna().reset_index(drop=True)\n",
+    "    scaler = MinMaxScaler()\n",
+    "    scaled = scaler.fit_transform(df[features])\n",
+    "    df_scaled = pd.DataFrame(scaled, columns=features)\n",
+    "    df_scaled['Target'] = df['Target'].values\n",
+    "    return df_scaled, features\n",
+    "\n",
+    "def create_sequences(df, features, seq_len=20):\n",
+    "    X, y = [], []\n",
+    "    data = df[features].values\n",
+    "    target = df['Target'].values\n",
+    "    for i in range(len(data) - seq_len):\n",
+    "        X.append(data[i:i+seq_len])\n",
+    "        y.append(target[i+seq_len])\n",
+    "    return np.array(X), np.array(y)\n",
+    "\n",
+    "def train_test_split(X, y, test_ratio=0.2):\n",
+    "    split = int(len(X) * (1 - test_ratio))\n",
+    "    return X[:split], X[split:], y[:split], y[split:]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Train CapsNet without indicators" 
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_base, base_features = load_data('MSFT_1986_2025-06-30.csv', use_indicators=False)\n",
+    "Xb, yb = create_sequences(df_base, base_features, seq_len=20)\n",
+    "Xb_train, Xb_test, yb_train, yb_test = train_test_split(Xb, yb)\n",
+    "\n",
+    "caps_base = build_capsnet((Xb_train.shape[1], Xb_train.shape[2]))\n",
+    "yb_train_ohe = tf.keras.utils.to_categorical(yb_train, 2)\n",
+    "caps_base.fit(Xb_train, yb_train_ohe, epochs=5, batch_size=32, verbose=0)\n",
+    "\n",
+    "base_pred_prob = caps_base.predict(Xb_test)\n",
+    "base_pred = np.argmax(base_pred_prob, axis=1)\n",
+    "metrics_base = evaluate(yb_test, base_pred)\n",
+    "metrics_base"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Train CapsNet with STC and CMO" 
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_ind, ind_features = load_data('MSFT_1986_2025-06-30.csv', use_indicators=True)\n",
+    "Xi, yi = create_sequences(df_ind, ind_features, seq_len=20)\n",
+    "Xi_train, Xi_test, yi_train, yi_test = train_test_split(Xi, yi)\n",
+    "\n",
+    "caps_ind = build_capsnet((Xi_train.shape[1], Xi_train.shape[2]))\n",
+    "yi_train_ohe = tf.keras.utils.to_categorical(yi_train, 2)\n",
+    "caps_ind.fit(Xi_train, yi_train_ohe, epochs=5, batch_size=32, verbose=0)\n",
+    "\n",
+    "ind_pred_prob = caps_ind.predict(Xi_test)\n",
+    "ind_pred = np.argmax(ind_pred_prob, axis=1)\n",
+    "metrics_ind = evaluate(yi_test, ind_pred)\n",
+    "metrics_ind"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Compare results" 
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('Metrics without indicators:', metrics_base)\n",
+    "print('Metrics with STC & CMO:', metrics_ind)\n",
+    "if metrics_ind['accuracy'] > metrics_base['accuracy']:\n",
+    "    print('Using indicators performed better based on accuracy')\n",
+    "else:\n",
+    "    print('Raw price features performed better based on accuracy')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3", 
+   "language": "python", 
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python", 
+   "version": "3.x"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
## Summary
- create a new notebook `capsnet_without_and_with_indicators.ipynb`
- train CapsNet model on Microsoft data with and without STC/CMO
- compute accuracy, recall and F1 and compare which approach performs better

## Testing
- `jq '.' capsnet_without_and_with_indicators.ipynb`

------
https://chatgpt.com/codex/tasks/task_e_68783c119834832da797e9b248b766a6