### PR TITLE
Add LSTM baseline vs indicators notebook

### DIFF
--- a/lstm_with_and_without_indicators.ipynb
+++ b/lstm_with_and_without_indicators.ipynb
@@ -1,0 +1,190 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# LSTM Prediction on Microsoft Stock\n",
+    "\n",
+    "This notebook trains an LSTM model on Microsoft stock data first **without** technical indicators and then **with** two indicators: Schaff Trend Cycle (STC) and Chande Momentum Oscillator (CMO).\n",
+    "Metrics reported are accuracy, recall and F1 score."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "from sklearn.preprocessing import MinMaxScaler\n",
+    "from sklearn.metrics import accuracy_score, recall_score, f1_score\n",
+    "from tensorflow.keras.models import Sequential\n",
+    "from tensorflow.keras.layers import LSTM, Dense"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["## Load Microsoft stock data"]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "df = pd.read_csv('MSFT_1986_2025-06-30.csv')\n",
+    "df['Date'] = pd.to_datetime(df['Date'])\n",
+    "df = df.sort_values('Date').reset_index(drop=True)\n",
+    "df['Target'] = (df['Close'].shift(-1) > df['Close']).astype(int)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["## Train LSTM without technical indicators"]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "basic_features = ['Close','High','Low','Open','Volume']\n",
+    "scaler = MinMaxScaler()\n",
+    "scaled = scaler.fit_transform(df[basic_features])\n",
+    "data = pd.DataFrame(scaled, columns=basic_features)\n",
+    "data['Target'] = df['Target']\n",
+    "data = data.dropna().reset_index(drop=True)\n",
+    "seq_len = 20\n",
+    "X, y = [], []\n",
+    "for i in range(len(data) - seq_len):\n",
+    "    X.append(data[basic_features].values[i:i+seq_len])\n",
+    "    y.append(data['Target'].iloc[i+seq_len])\n",
+    "X, y = np.array(X), np.array(y)\n",
+    "split = int(0.8 * len(X))\n",
+    "X_train, X_test = X[:split], X[split:]\n",
+    "y_train, y_test = y[:split], y[split:]\n",
+    "model_basic = Sequential([\n",
+    "    LSTM(50, input_shape=(seq_len, len(basic_features))),\n",
+    "    Dense(1, activation='sigmoid')\n",
+    "])\n",
+    "model_basic.compile(optimizer='adam', loss='binary_crossentropy', metrics=['accuracy'])\n",
+    "model_basic.fit(X_train, y_train, epochs=5, batch_size=32, verbose=0)\n",
+    "pred_basic = (model_basic.predict(X_test) > 0.5).astype(int).flatten()\n",
+    "acc_basic = accuracy_score(y_test, pred_basic)\n",
+    "recall_basic = recall_score(y_test, pred_basic)\n",
+    "f1_basic = f1_score(y_test, pred_basic)\n",
+    "print('Without indicators - Acc:', acc_basic, 'Recall:', recall_basic, 'F1:', f1_basic)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["## Calculate STC and CMO indicators"]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "def schaff_trend_cycle(close, fast_period=23, slow_period=50, cycle_period=10):\n",
+    "    ema_fast = close.ewm(span=fast_period, adjust=False).mean()\n",
+    "    ema_slow = close.ewm(span=slow_period, adjust=False).mean()\n",
+    "    macd = ema_fast - ema_slow\n",
+    "    lowest_macd = macd.rolling(window=cycle_period).min()\n",
+    "    highest_macd = macd.rolling(window=cycle_period).max()\n",
+    "    stoch_macd = 100 * (macd - lowest_macd) / (highest_macd - lowest_macd)\n",
+    "    stoch_macd_smoothed1 = stoch_macd.ewm(span=3, adjust=False).mean()\n",
+    "    stoch_macd_smoothed2 = stoch_macd_smoothed1.ewm(span=3, adjust=False).mean()\n",
+    "    return stoch_macd_smoothed2\n",
+    "\n",
+    "def chande_momentum_oscillator(close, window=14):\n",
+    "    delta = close.diff()\n",
+    "    gains = delta.where(delta > 0, 0)\n",
+    "    losses = -delta.where(delta < 0, 0)\n",
+    "    sum_gains = gains.rolling(window=window).sum()\n",
+    "    sum_losses = losses.rolling(window=window).sum()\n",
+    "    cmo = 100 * (sum_gains - sum_losses) / (sum_gains + sum_losses)\n",
+    "    return cmo\n",
+    "\n",
+    "df['STC'] = schaff_trend_cycle(df['Close'])\n",
+    "df['CMO'] = chande_momentum_oscillator(df['Close'])\n",
+    "df_ind = df.dropna().reset_index(drop=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["## Train LSTM with STC and CMO indicators"]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "feat_ind = ['Close','High','Low','Open','Volume','STC','CMO']\n",
+    "scaler_ind = MinMaxScaler()\n",
+    "scaled_ind = scaler_ind.fit_transform(df_ind[feat_ind])\n",
+    "data_ind = pd.DataFrame(scaled_ind, columns=feat_ind)\n",
+    "data_ind['Target'] = df_ind['Target'].values\n",
+    "seq_len = 20\n",
+    "X2, y2 = [], []\n",
+    "for i in range(len(data_ind) - seq_len):\n",
+    "    X2.append(data_ind[feat_ind].values[i:i+seq_len])\n",
+    "    y2.append(data_ind['Target'].iloc[i+seq_len])\n",
+    "X2, y2 = np.array(X2), np.array(y2)\n",
+    "split2 = int(0.8 * len(X2))\n",
+    "X2_train, X2_test = X2[:split2], X2[split2:]\n",
+    "y2_train, y2_test = y2[:split2], y2[split2:]\n",
+    "model_ind = Sequential([\n",
+    "    LSTM(50, input_shape=(seq_len, len(feat_ind))),\n",
+    "    Dense(1, activation='sigmoid')\n",
+    "])\n",
+    "model_ind.compile(optimizer='adam', loss='binary_crossentropy', metrics=['accuracy'])\n",
+    "model_ind.fit(X2_train, y2_train, epochs=5, batch_size=32, verbose=0)\n",
+    "pred_ind = (model_ind.predict(X2_test) > 0.5).astype(int).flatten()\n",
+    "acc_ind = accuracy_score(y2_test, pred_ind)\n",
+    "recall_ind = recall_score(y2_test, pred_ind)\n",
+    "f1_ind = f1_score(y2_test, pred_ind)\n",
+    "print('With indicators - Acc:', acc_ind, 'Recall:', recall_ind, 'F1:', f1_ind)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["## Compare results"]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "print('Without indicators - Acc:', acc_basic, 'Recall:', recall_basic, 'F1:', f1_basic)\n",
+    "print('With indicators - Acc:', acc_ind, 'Recall:', recall_ind, 'F1:', f1_ind)\n",
+    "if acc_ind > acc_basic:\n",
+    "    print('LSTM with indicators performed better.')\n",
+    "else:\n",
+    "    print('LSTM without indicators performed better.')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add new notebook that compares LSTM models on Microsoft stock data
- first train without indicators
- then train with STC and CMO
- print accuracy, recall and F1 for both approaches

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68783fca06ac832dbcec6827f8750443