### PR TITLE
Add LSTM vs CapsNet notebook with STC and CMO

### DIFF
--- a/lstm_capsnet_stc_cmo.ipynb
+++ b/lstm_capsnet_stc_cmo.ipynb
@@ -1,0 +1,297 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# LSTM vs CapsNet on Microsoft Stock\n",
+    "\n",
+    "This notebook uses the provided Microsoft stock data to train two deep learning models:\n",
+    "an LSTM network and a Capsule Network. Both models incorporate the Schaff Trend Cycle (STC)\n",
+    "and Chande Momentum Oscillator (CMO) indicators. Multiple metrics are reported to compare\n",
+    "their performance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "from sklearn.preprocessing import MinMaxScaler\n",
+    "from sklearn.metrics import accuracy_score, precision_score, recall_score, f1_score\n",
+    "from tensorflow.keras import layers, models\n",
+    "import tensorflow as tf"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Technical indicator functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def schaff_trend_cycle(close, fast_period=23, slow_period=50, cycle_period=10):\n",
+    "    ema_fast = close.ewm(span=fast_period, adjust=False).mean()\n",
+    "    ema_slow = close.ewm(span=slow_period, adjust=False).mean()\n",
+    "    macd = ema_fast - ema_slow\n",
+    "    lowest_macd = macd.rolling(window=cycle_period).min()\n",
+    "    highest_macd = macd.rolling(window=cycle_period).max()\n",
+    "    stoch_macd = 100 * (macd - lowest_macd) / (highest_macd - lowest_macd)\n",
+    "    stoch_macd_smoothed1 = stoch_macd.ewm(span=3, adjust=False).mean()\n",
+    "    stoch_macd_smoothed2 = stoch_macd_smoothed1.ewm(span=3, adjust=False).mean()\n",
+    "    return stoch_macd_smoothed2\n",
+    "\n",
+    "def chande_momentum_oscillator(close, window=14):\n",
+    "    delta = close.diff()\n",
+    "    gains = delta.where(delta > 0, 0)\n",
+    "    losses = -delta.where(delta < 0, 0)\n",
+    "    sum_gains = gains.rolling(window=window).sum()\n",
+    "    sum_losses = losses.rolling(window=window).sum()\n",
+    "    cmo = 100 * (sum_gains - sum_losses) / (sum_gains + sum_losses)\n",
+    "    return cmo"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load and prepare the data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.read_csv('MSFT_1986_2025-06-30.csv')\n",
+    "df['Date'] = pd.to_datetime(df['Date'])\n",
+    "df = df.sort_values('Date').reset_index(drop=True)\n",
+    "df['STC'] = schaff_trend_cycle(df['Close'])\n",
+    "df['CMO'] = chande_momentum_oscillator(df['Close'])\n",
+    "df['Target'] = (df['Close'].shift(-1) > df['Close']).astype(int)\n",
+    "df = df.dropna().reset_index(drop=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Helper functions for sequence creation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def create_sequences(df, features, seq_len=20):\n",
+    "    X, y = [], []\n",
+    "    data = df[features].values\n",
+    "    target = df['Target'].values\n",
+    "    for i in range(len(data) - seq_len):\n",
+    "        X.append(data[i:i+seq_len])\n",
+    "        y.append(target[i+seq_len])\n",
+    "    return np.array(X), np.array(y)\n",
+    "\n",
+    "def train_test_split(X, y, test_ratio=0.2):\n",
+    "    split = int(len(X) * (1 - test_ratio))\n",
+    "    return X[:split], X[split:], y[:split], y[split:]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Build LSTM and CapsNet models"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def build_lstm(input_shape):\n",
+    "    model = models.Sequential([\n",
+    "        layers.LSTM(50, input_shape=input_shape),\n",
+    "        layers.Dense(1, activation='sigmoid')\n",
+    "    ])\n",
+    "    model.compile(optimizer='adam', loss='binary_crossentropy', metrics=['accuracy'])\n",
+    "    return model\n",
+    "\n",
+    "def squash(vectors, axis=-1):\n",
+    "    s_squared_norm = tf.reduce_sum(tf.square(vectors), axis=axis, keepdims=True)\n",
+    "    scale = s_squared_norm / (1 + s_squared_norm) / tf.sqrt(s_squared_norm + 1e-7)\n",
+    "    return scale * vectors\n",
+    "\n",
+    "class CapsuleLayer(layers.Layer):\n",
+    "    def __init__(self, num_capsules, dim_capsule, routings=3, **kwargs):\n",
+    "        super().__init__(**kwargs)\n",
+    "        self.num_capsules = num_capsules\n",
+    "        self.dim_capsule = dim_capsule\n",
+    "        self.routings = routings\n",
+    "\n",
+    "    def build(self, input_shape):\n",
+    "        self.input_num_capsules = input_shape[1]\n",
+    "        self.input_dim_capsule = input_shape[2]\n",
+    "        self.W = self.add_weight(\n",
+    "            shape=[1, self.input_num_capsules, self.num_capsules,\n",
+    "                   self.input_dim_capsule, self.dim_capsule],\n",
+    "            initializer='glorot_uniform',\n",
+    "            trainable=True,\n",
+    "            name='W'\n",
+    "        )\n",
+    "\n",
+    "    def call(self, inputs):\n",
+    "        batch_size = tf.shape(inputs)[0]\n",
+    "        inputs_expand = tf.expand_dims(tf.expand_dims(inputs, 2), 2)\n",
+    "        inputs_tiled = tf.tile(inputs_expand, [1, 1, self.num_capsules, 1, 1])\n",
+    "        W_tiled = tf.tile(self.W, [batch_size, 1, 1, 1, 1])\n",
+    "        u_hat = tf.matmul(inputs_tiled, W_tiled)\n",
+    "        u_hat = tf.squeeze(u_hat, [3])\n",
+    "        b = tf.zeros([batch_size, self.input_num_capsules, self.num_capsules, 1])\n",
+    "        for i in range(self.routings):\n",
+    "            c = tf.nn.softmax(b, axis=2)\n",
+    "            s = tf.reduce_sum(c * u_hat, axis=1, keepdims=True)\n",
+    "            v = squash(s)\n",
+    "            if i < self.routings - 1:\n",
+    "                b += tf.reduce_sum(u_hat * v, axis=-1, keepdims=True)\n",
+    "        return tf.squeeze(v, [1])\n",
+    "\n",
+    "class Length(layers.Layer):\n",
+    "    def call(self, inputs, **kwargs):\n",
+    "        return tf.sqrt(tf.reduce_sum(tf.square(inputs), axis=-1))\n",
+    "\n",
+    "def build_capsnet(input_shape, num_classes=2):\n",
+    "    inputs = layers.Input(shape=input_shape)\n",
+    "    x = layers.Conv1D(64, 5, padding='same', activation='relu')(inputs)\n",
+    "    x = layers.BatchNormalization()(x)\n",
+    "    x = layers.Conv1D(32, 5, strides=2, activation='relu')(x)\n",
+    "    x = layers.Reshape((-1, 8))(x)\n",
+    "    x = layers.Lambda(squash)(x)\n",
+    "    digitcaps = CapsuleLayer(num_capsules=num_classes, dim_capsule=8, routings=3)(x)\n",
+    "    out_caps = Length()(digitcaps)\n",
+    "    model = models.Model(inputs, out_caps)\n",
+    "    model.compile(optimizer='adam', loss='binary_crossentropy', metrics=['accuracy'])\n",
+    "    return model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare sequences for training"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "features = ['Close','High','Low','Open','Volume','STC','CMO']\n",
+    "scaler = MinMaxScaler()\n",
+    "scaled = scaler.fit_transform(df[features])\n",
+    "df_scaled = pd.DataFrame(scaled, columns=features)\n",
+    "df_scaled['Target'] = df['Target'].values\n",
+    "X, y = create_sequences(df_scaled, features, seq_len=20)\n",
+    "X_train, X_test, y_train, y_test = train_test_split(X, y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Train the LSTM model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lstm_model = build_lstm((X_train.shape[1], X_train.shape[2]))\n",
+    "lstm_model.fit(X_train, y_train, epochs=5, batch_size=32, verbose=0)\n",
+    "lstm_pred = (lstm_model.predict(X_test) > 0.5).astype(int).flatten()\n",
+    "lstm_metrics = {\n",
+    "    'accuracy': accuracy_score(y_test, lstm_pred),\n",
+    "    'precision': precision_score(y_test, lstm_pred),\n",
+    "    'recall': recall_score(y_test, lstm_pred),\n",
+    "    'f1': f1_score(y_test, lstm_pred)\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Train the Capsule Network"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "caps_model = build_capsnet((X_train.shape[1], X_train.shape[2]))\n",
+    "y_train_ohe = tf.keras.utils.to_categorical(y_train, 2)\n",
+    "caps_model.fit(X_train, y_train_ohe, epochs=5, batch_size=32, verbose=0)\n",
+    "caps_pred_prob = caps_model.predict(X_test)\n",
+    "caps_pred = np.argmax(caps_pred_prob, axis=1)\n",
+    "caps_metrics = {\n",
+    "    'accuracy': accuracy_score(y_test, caps_pred),\n",
+    "    'precision': precision_score(y_test, caps_pred),\n",
+    "    'recall': recall_score(y_test, caps_pred),\n",
+    "    'f1': f1_score(y_test, caps_pred)\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Compare the results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('LSTM metrics:', lstm_metrics)\n",
+    "print('CapsNet metrics:', caps_metrics)\n",
+    "if caps_metrics['accuracy'] > lstm_metrics['accuracy']:\n",
+    "    print('CapsNet performed better based on accuracy')\n",
+    "else:\n",
+    "    print('LSTM performed better based on accuracy')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add new Jupyter notebook `lstm_capsnet_stc_cmo.ipynb`
- notebook trains LSTM and Capsule Network using Schaff Trend Cycle and Chande Momentum Oscillator indicators on Microsoft stock data
- evaluates both models with accuracy, precision, recall and F1 metrics and prints which performs better

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687849bee6d0832db47a369d2daf14bb